### PR TITLE
Potential fix for code scanning alert no. 1: Unbounded write

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,7 +3,8 @@
 
 void vulnerable_function(char *input) {
     char buffer[10];
-    strcpy(buffer, input); // Vulnerability: buffer overflow
+    strncpy(buffer, input, sizeof(buffer) - 1); // Safe copy with size limit
+    buffer[sizeof(buffer) - 1] = '\0'; // Ensure null termination
     std::cout << "Buffer content: " << buffer << std::endl;
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/aneesh-sayal-tkd/code_ql_test/security/code-scanning/1](https://github.com/aneesh-sayal-tkd/code_ql_test/security/code-scanning/1)

To fix the problem, the unbounded `strcpy` call should be replaced with a safer alternative, such as `strncpy`, which allows specifying the maximum number of characters to copy. This ensures that the input does not exceed the size of the destination buffer. Additionally, the code should handle cases where the input is truncated to fit the buffer size, ensuring the program remains stable and functional.

The fix involves:
1. Replacing `strcpy` with `strncpy`.
2. Specifying the maximum number of characters to copy as the size of the buffer minus one (to leave space for the null terminator).
3. Explicitly null-terminating the buffer after copying to ensure it is a valid C-string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
