### PR TITLE
Potential fix for code scanning alert no. 3: Unbounded write

### DIFF
--- a/src/unsafe.cpp
+++ b/src/unsafe.cpp
@@ -6,7 +6,8 @@ void vulnerable() {
     char dest[10];
     char* src = getenv("USER");  // ← source of untrusted data
     if (src != nullptr) {
-        strcpy(dest, src);       // 🚨 Vulnerable: no bounds checking
+        strncpy(dest, src, sizeof(dest) - 1);  // Safe: limit copy to buffer size minus one
+        dest[sizeof(dest) - 1] = '\0';        // Ensure null termination
         std::cout << "Copied username: " << dest << std::endl;
     }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/aneesh-sayal-tkd/code_ql_test/security/code-scanning/3](https://github.com/aneesh-sayal-tkd/code_ql_test/security/code-scanning/3)

To fix the issue, we should replace the unsafe `strcpy` function with a safer alternative like `strncpy`. The `strncpy` function allows us to specify the maximum number of characters to copy, preventing buffer overflows. In this case, we will limit the copy operation to the size of the `dest` buffer minus one to ensure space for the null terminator. Additionally, we will explicitly null-terminate the `dest` buffer to account for scenarios where `src` exceeds the specified length. 

The changes will be confined to the `vulnerable` function in `src/unsafe.cpp`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
